### PR TITLE
Adding pageRef to newPage() call.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 ZZO Associates
+ * Copyright (c) 2013 ZZO Associates
  */
 
 var http = require('http')
@@ -126,7 +126,7 @@ Proxy.prototype = {
     },
 
     newPage: function(port, name, cb) {
-        this.doReq('PUT', '/proxy/' + port + '/har', 'pageRef=' + name, cb);
+        this.doReq('PUT', '/proxy/' + port + '/har/pageRef', 'pageRef=' + name, cb);
     },
 
     /*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "browsermob-proxy",
   "description": "Javascript bindings for the browsermob-proxy",
   "keywords": ["selenium", "test", "testing", "proxy", "tests", "har"],
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Mark Ethan Trostler <mark@zzo.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- url for newPage() is now in the format: /proxy/[PORT]/har/pageRef
- updating copyright year.
- updating package version to 1.0.6
