### PR TITLE
Enable to set capture{Headers,Content,BinaryContent} in cbHAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ proxy.doHAR('http://yahoo.com', function(err, data) {
 });
 ```
 
-**cbHAR(NAME, GENERATE_TRAFFIC_CALLBACK, HAR_CALLBACK)**
+**cbHAR(OPTIONS, GENERATE_TRAFFIC_CALLBACK, HAR_CALLBACK)**
 
 Convenience method to get HAR data - this method allows you to generate whatever traffic you like (via the CALLBACK), and then generate the HAR file.  
 
 PARAMETERS
 
-    * NAME is an abritrary name for this run - like 'yahoo.com' or whatever you like.
+    * OPTIONS is an object with keys 'name', 'captureHeaders', 'captureContent' and 'captureBinaryContent'; 'name' is an abritrary name for this run - like 'yahoo.com' or whatever you like; 'captureHeaders', 'captureContent' and 'captureBinaryContent' expect booleans indicating whether to capture resp headers, body of http transactions, and binary body of transactions. For backwards compatibility reasons, if OPTIONS is a string, it will be interpreted as the name for the run.
     * GENERATE_TRAFFIC_CALLBACK(PROXY, DONE_CALLBACK)
 
         PARAMETERS

--- a/index.js
+++ b/index.js
@@ -37,11 +37,14 @@ Proxy.prototype = {
             .end(cb);
     },
 
-    cbHAR:  function(name, selCB, cb) {
+    cbHAR:  function(options, selCB, cb) {
         var _this = this;
+        if (typeof options === "string") {
+            options = { name: options};
+        }
         this.start(function(err, data) {
             if (!err) {
-                _this.startHAR(data.port, name, function(err, resp) {
+                _this.startHAR(data.port, options.name, options.captureHeaders, options.captureContent, options.captureBinaryContent, function(err, resp) {
                     if (!err) {
                         selCB(_this.host + ':' + data.port, function () {
                             _this.getHAR(data.port, function(err, resp) {


### PR DESCRIPTION
This makes it possible to configure a given HAR to record headers etc when using cbHAR
