### PR TITLE
Allow a port to be specified in cbHAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Convenience method to get HAR data - this method allows you to generate whatever
 
 PARAMETERS
 
-    * OPTIONS is an object with keys 'name', 'captureHeaders', 'captureContent' and 'captureBinaryContent'; 'name' is an abritrary name for this run - like 'yahoo.com' or whatever you like; 'captureHeaders', 'captureContent' and 'captureBinaryContent' expect booleans indicating whether to capture resp headers, body of http transactions, and binary body of transactions. For backwards compatibility reasons, if OPTIONS is a string, it will be interpreted as the name for the run.
+    * OPTIONS is an object with keys 'port', 'name', 'captureHeaders', 'captureContent' and 'captureBinaryContent'; 'port' the port number on which this proxy should be available; 'name' is an abritrary name for this run - like 'yahoo.com' or whatever you like; 'captureHeaders', 'captureContent' and 'captureBinaryContent' expect booleans indicating whether to capture resp headers, body of http transactions, and binary body of transactions. For backwards compatibility reasons, if OPTIONS is a string, it will be interpreted as the name for the run.
     * GENERATE_TRAFFIC_CALLBACK(PROXY, DONE_CALLBACK)
 
         PARAMETERS

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ Proxy.prototype = {
         if (typeof options === "string") {
             options = { name: options};
         }
-        this.start(function(err, data) {
+        this.start(options.port, function(err, data) {
             if (!err) {
                 _this.startHAR(data.port, options.name, options.captureHeaders, options.captureContent, options.captureBinaryContent, function(err, resp) {
                     if (!err) {


### PR DESCRIPTION
Allow configuration of the proxyPort via the configuration object when creating the proxy, and/or by passing the  port as a parameter to doHAR / cbHAR functions.

This is a mix of Pull Request : "Use specific proxy port for proxy sessions #8" which allows specifying proxyPort in conf object of new Proxy(conf)

*and*

My pull request 19 allowing proxyPort to be passed to cbHAR and doHAR convenience functions.

These changes would be really useful in cases where the user specifies the selenium httpProxy host:port in advance such as in a Nightwatch or theIntern configuration file, and then needs to make sure that tests running against it create the mobbrowser-proxy against the same port, rather than an incremenetally chosen one.

Otherwise, tests either have to : 
a.) predict the port - not always possible when tests run in parallel in different orders
b.) write their own fine-tuned proxy start - run - stop behaviour
