### PR TITLE
add filterRequest and filterResponse bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,3 +413,25 @@ Full API
         * REWRITE_OBJ an object with 2 mandatory keys: matchRegex and replace. Any set keys will be set on the specified proxy port
         * CALLBACK(ERROR) function
             1. ERROR string if there was an error
+
+**filterRequest(PORT, FILTER_DATA, CALLBACK)**
+    
+    Allows intercepting requests for proxy on PORT
+
+    PARAMETERS:
+
+        * PORT of proxy for this command
+        * FILTER_DATA string with code to intercept requests. Javascript request filters have access to the variables `request` (type io.netty.handler.codec.http.HttpRequest), `contents` (type net.lightbody.bmp.util.HttpMessageContents), and `messageInfo` (type net.lightbody.bmp.util.HttpMessageInfo). `messageInfo` contains additional information about the message.
+        * CALLBACK(ERROR) function
+            1. ERROR string if there was an error
+
+**filterResponse(PORT, FILTER_DATA, CALLBACK)**
+    
+    Allows intercepting responses for proxy on PORT
+
+    PARAMETERS:
+
+        * PORT of proxy for this command
+        * FILTER_DATA string with code to intercept responses. Javascript response filters have access to the variables `response` (type io.netty.handler.codec.http.HttpResponse), `contents` (type net.lightbody.bmp.util.HttpMessageContents), and `messageInfo` (type net.lightbody.bmp.util.HttpMessageInfo). As in the request filter, `messageInfo` contains additional information about the message.
+        * CALLBACK(ERROR) function
+            1. ERROR string if there was an error

--- a/index.js
+++ b/index.js
@@ -220,6 +220,24 @@ Proxy.prototype = {
         this.doReq("PUT", "/proxy/" + port + "/rewrite", data, cb);
     },
 
+    filterRequest: function (port, data, cb) {
+        var options = {
+            host: this.host, port: this.port, method: 'POST', path: '/proxy/' + port + '/filter/request', headers: {
+                'Content-Type': 'text/plain'
+            }
+        };
+        this.doReqWithOptions(options, data, cb);
+    },
+
+    filterResponse: function (port, data, cb) {
+        var options = {
+            host: this.host, port: this.port, method: 'POST', path: '/proxy/' + port + '/filter/response', headers: {
+                'Content-Type': 'text/plain'
+            }
+        };
+        this.doReqWithOptions(options, data, cb);
+    },
+
     doReq: function (method, url, postData, cb) {
         var options = {
             host: this.host, port: this.port, method: method, path: url, headers: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "browsermob-proxy",
   "description": "Javascript bindings for the browsermob-proxy",
   "keywords": ["selenium", "test", "testing", "proxy", "tests", "har"],
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "Mark Ethan Trostler <mark@zzo.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I added methods to use filter request and response of browsermob-proxy. This allows interception of the contents so eg. it is possible to affect what we send in the payload.