### PR TITLE
feat(start): add optional parameter to trust all certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,13 +311,14 @@ The sequence is
 Full API
 --------
 
-**start([ PORT ], CALLBACK)**
+**start([ PORT ], [ TRUSTALLCERTS ], CALLBACK)**
 
     Initializes a proxy
 
     PARAMETERS:
 
         * an optional PORT parameter specifying which port to open up a proxy on - if not provided browsermob will pick one.
+        * an optional TRUSTALLCERTS parameter is a boolean value specifying whether to trust all upstream SSL certificates irrespective of their validity - if not provided will default to false
         * CALLBACK(ERROR, DATA) function
             1. ERROR string if there was an error
             2. DATA object whose only member is 'port' - the port the proxy is listening on

--- a/index.js
+++ b/index.js
@@ -40,11 +40,12 @@ Proxy.prototype = {
 
     cbHAR:  function(options, selCB, cb) {
         var _this = this,
-            port  = options.proxyPort || this.proxyPort;
+            port  = options.proxyPort || this.proxyPort,
+            trustAllServers = options.trustAllServers || false;
         if (typeof options === "string") {
             options = { name: options};
         }
-        this.start(port, function(err, data) {
+        this.start(port, trustAllServers, function(err, data) {
             if (!err) {
                 _this.startHAR(data.port, options.name, options.captureHeaders, options.captureContent, options.captureBinaryContent, function(err, resp) {
                     if (!err) {
@@ -69,13 +70,17 @@ Proxy.prototype = {
          });
     },
 
-    start: function(port, cb) {
+    start: function(port, trustAllServers, cb) {
         var postData = '';
         if (!cb) {
             cb = port;
         }
         if (typeof(port) === 'number') {
             postData = 'port=' + port;
+        }
+
+        if (typeof trustAllServers == 'boolean') {
+            postData = 'trustAllServers=' + trustAllServers;
         }
 
         this.doReq('POST', '/proxy', postData, function(err, data) {
@@ -161,10 +166,11 @@ Proxy.prototype = {
         this.doReq('PUT', '/proxy/' + port + '/limit', data, cb);
     },
 
-    doHAR: function(url, cb, proxyPort) {
+    doHAR: function(url, cb, proxyPort, trustAllServers) {
         var _this = this,
-            port  = proxyPort || this.proxyPort;
-        this.start(port, function(err, data) {
+            port  = proxyPort || this.proxyPort,
+            trustAllServers = trustAllServers || false;
+        this.start(port, trustAllServers, function(err, data) {
             if (!err) {
                 _this.startHAR(data.port, url, function(err, resp) {
                     if (!err) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "browsermob-proxy",
   "description": "Javascript bindings for the browsermob-proxy",
   "keywords": ["selenium", "test", "testing", "proxy", "tests", "har"],
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "Mark Ethan Trostler <mark@zzo.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `trustAllServers ` is a parameter available to the [REST API](https://github.com/lightbody/browsermob-proxy#rest-api) 
 `POST /proxy` call. This PR adds it as an additional argument to the start method.

This should allow for proxying to HTTPS services that do not have valid SSL certs